### PR TITLE
Add a short note to install shush using curl for Linux/Unix users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ Binaries for official releases may be downloaded from the [releases page on GitH
 If you want to compile it from source, try:
 
     $ go get github.com/realestate-com-au/shush
+    
+For Unix/Linux users, you can install `shush` using the following command. You may want to change the version number in the command below from `v1.3.4` to whichever version you want:
+
+```
+curl -sL -o /usr/local/bin/shush \
+    https://github.com/realestate-com-au/shush/releases/download/v1.3.4/shush_linux_amd64 \
+ && chmod +x /usr/local/bin/shush
+```
 
 ## Examples
 


### PR DESCRIPTION
I think this helps beginners in installing `shush` and making it readily available in `/usr/local/bin/`.