### PR TITLE
Added option to print the key

### DIFF
--- a/kms/kms_handle.go
+++ b/kms/kms_handle.go
@@ -68,17 +68,22 @@ func (h *KmsHandle) Encrypt(plaintext string, keyID string) (string, error) {
 }
 
 // Decrypt ciphertext.
-func (h *KmsHandle) Decrypt(ciphertext string) (string, error) {
+func (h *KmsHandle) Decrypt(ciphertext string) (string, string, error) {
 	ciphertextBlob, err := base64.StdEncoding.DecodeString(ciphertext)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	output, err := h.Client.Decrypt(&kms.DecryptInput{
 		EncryptionContext: h.Context,
 		CiphertextBlob:    ciphertextBlob,
 	})
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	return string(output.Plaintext), nil
+
+	keyId := ""
+	if output.KeyId != nil {
+		keyId = *output.KeyId
+	}
+	return string(output.Plaintext), keyId, nil
 }

--- a/main.go
+++ b/main.go
@@ -60,6 +60,12 @@ func main() {
 		{
 			Name:  "decrypt",
 			Usage: "Decrypt KMS ciphertext",
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "print-key",
+					Usage: "Print the key instead of the deciphered text",
+				},
+			},
 			Action: func(c *cli.Context) {
 				handle, err := kms.NewHandle(
 					c.GlobalString("region"),
@@ -72,11 +78,15 @@ func main() {
 				if err != nil {
 					sys.Abort(sys.UsageError, err)
 				}
-				plaintext, err := handle.Decrypt(ciphertext)
+				plaintext, keyId, err := handle.Decrypt(ciphertext)
 				if err != nil {
 					sys.Abort(sys.KmsError, err)
 				}
-				fmt.Print(plaintext)
+				if c.Bool("print-key") {
+					fmt.Print(keyId)
+				} else {
+					fmt.Print(plaintext)
+				}
 			},
 		},
 		{
@@ -113,7 +123,7 @@ func main() {
 						if strings.HasPrefix(key, encryptedVarPrefix) {
 							ciphertext := keyValuePair[1]
 							plaintextKey := key[len(encryptedVarPrefix):len(key)]
-							plaintext, err := handle.Decrypt(ciphertext)
+							plaintext, _, err := handle.Decrypt(ciphertext)
 							if err != nil {
 								sys.Abort(sys.KmsError, fmt.Sprintf("cannot decrypt $%s; %s\n", key, err))
 							}


### PR DESCRIPTION
Currently, the `decrypt` subcommand directly prints out the deciphered plain text. This PR adds a flag which allows the `key id` to be printed instead. This can be useful for checking the key used to encrypt (in case, someone is juggling multiple keys for various use cases).