### PR TITLE
README: Fix versioned url in curl example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ In this example, "shush exec":
 
     # Include "shush" to decode KMS_ENCRYPTED_STUFF
     RUN curl -sL -o /usr/local/bin/shush \
-        https://github.com/realestate-com-au/shush/releases/download/v1.3.0/shush_linux_amd64 \
+        https://github.com/realestate-com-au/shush/releases/download/v1.3.4/shush_linux_amd64 \
      && chmod +x /usr/local/bin/shush
     ENTRYPOINT ["/usr/local/bin/shush", "exec", "--"]
 


### PR DESCRIPTION
Bump to newest released shush, v1.3.4.