### PR TITLE
Add a flag to trim whitespace when encrypting

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Plaintext input can also be provided on the command-line, e.g.
 
     shush encrypt KEY-ID 'this is a secret' > secret.encrypted
 
+With the `-t` or `--trim` flag, `encrypt` will automatically remove leading and trailing whitespace from the plaintext. This can be especially useful when piping input from commands which always leave a trailing newline.
+
+    shush encrypt -t KEY_ID ' I don't really need this whitespace ' > secret.encrypted
+
 ### Decrypting things
 
 Encrypted secrets are easy to decrypt, like this:
@@ -30,7 +34,7 @@ There's no need to specify a KEY-ID here, as it's encoded in the ciphertext.
 
 Appropriate AWS credentials must be provided by one of the [mechanisms supported by aws-sdk-go](https://github.com/aws/aws-sdk-go/wiki/Getting-Started-Credentials), e.g. environment variables, or EC2 instance profile.
 
-When used within EC2, `shush` selects the appropriate region automatically.  
+When used within EC2, `shush` selects the appropriate region automatically.
 Outside EC2, you'll need to specify it, via `--region` or by setting `$AWS_DEFAULT_REGION`.
 
 ### Encryption context
@@ -81,7 +85,7 @@ Binaries for official releases may be downloaded from the [releases page on GitH
 If you want to compile it from source, try:
 
     $ go get github.com/realestate-com-au/shush
-    
+
 For Unix/Linux users, you can install `shush` using the following command. You may want to change the version number in the command below from `v1.3.4` to whichever version you want:
 
 ```

--- a/main.go
+++ b/main.go
@@ -34,6 +34,12 @@ func main() {
 		{
 			Name:  "encrypt",
 			Usage: "Encrypt with a KMS key",
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name: "trim, t",
+					Usage: "If set, remove leading and trailing whitespace from plaintext",
+				},
+			},
 			Action: func(c *cli.Context) {
 				if len(c.Args()) == 0 {
 					sys.Abort(sys.UsageError, "no key specified")
@@ -49,6 +55,9 @@ func main() {
 				plaintext, err := sys.GetPayload(c.Args()[1:])
 				if err != nil {
 					sys.Abort(sys.UsageError, err)
+				}
+				if(c.Bool("trim")) {
+					plaintext = strings.TrimSpace(plaintext)
 				}
 				ciphertext, err := handle.Encrypt(plaintext, key)
 				if err != nil {


### PR DESCRIPTION
We use shush quite a lot at Redbubble. The most common issue we see comes when someone accidentally encrypts some whitespace, either by a) copying a string from a web form or b) pipes output from a shell command which automatically adds a newline.

Not sure if you consider this to be within the scope of the tool (totally understand if not!), but we thought it might make sense to have a flag in shush to (optionally, of course) trim whitespace when encrypting strings.

Let me know if you have any questions.