### PR TITLE
Hurray! Version 1.4.0 is here!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ install:
 
 build:
 	gox -osarch "linux/amd64 darwin/amd64 windows/amd64"
+
+test:
+	go test ./...

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 Encrypt secrets like this:
 
-    shush encrypt KEY-ID < secret.txt > secret.encrypted
+    shush encrypt KEY-ID-OR-ALIAS < secret.txt > secret.encrypted
 
 The output of `encrypt` is Base64-encoded ciphertext.
 
-KEY-ID can be the id or ARN of a KMS master key, or alias prefixed by "alias/".  See documentation on [Encrypt](http://docs.aws.amazon.com/kms/latest/APIReference/API_Encrypt.html) for more details.
+KEY-ID-OR-ALIAS can be the id or ARN of a KMS master key, or alias prefixed by "alias/", or simply just the alias.
 
 Plaintext input can also be provided on the command-line, e.g.
 
@@ -131,7 +131,7 @@ Or, you can just use `bash`, `base64`, and the AWS CLI:
 
 ## License
 
-Copyright (c) 2015 REA Group Ltd.
+Copyright (c) 2019 REA Group Ltd.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Encrypted secrets are easy to decrypt, like this:
 
 There's no need to specify a KEY-ID here, as it's encoded in the ciphertext.
 
+## Finding the key that was used
+
+If you want to see the ARN of the key used to encrypt the secret, add the `--print-key` flag
+
+    shush decrypt --print-key < secret.encrypted
+
 ### Credentials and region
 
 Appropriate AWS credentials must be provided by one of the [mechanisms supported by aws-sdk-go](https://github.com/aws/aws-sdk-go/wiki/Getting-Started-Credentials), e.g. environment variables, or EC2 instance profile.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ In this example, "shush exec":
 
     # Include "shush" to decode KMS_ENCRYPTED_STUFF
     RUN curl -sL -o /usr/local/bin/shush \
-        https://github.com/realestate-com-au/shush/releases/download/v1.3.4/shush_linux_amd64 \
+        https://github.com/realestate-com-au/shush/releases/download/v1.4.0/shush_linux_amd64 \
      && chmod +x /usr/local/bin/shush
     ENTRYPOINT ["/usr/local/bin/shush", "exec", "--"]
 
@@ -92,11 +92,11 @@ If you want to compile it from source, try:
 
     $ go get github.com/realestate-com-au/shush
 
-For Unix/Linux users, you can install `shush` using the following command. You may want to change the version number in the command below from `v1.3.4` to whichever version you want:
+For Unix/Linux users, you can install `shush` using the following command. You may want to change the version number in the command below from `v1.4.0` to whichever version you want:
 
 ```
 curl -sL -o /usr/local/bin/shush \
-    https://github.com/realestate-com-au/shush/releases/download/v1.3.4/shush_linux_amd64 \
+    https://github.com/realestate-com-au/shush/releases/download/v1.4.0/shush_linux_amd64 \
  && chmod +x /usr/local/bin/shush
 ```
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ Or, you can just use `bash`, `base64`, and the AWS CLI:
     base64 -d < secrets.encrypted > /tmp/secrets.bin
     aws kms decrypt --ciphertext-blob fileb:///tmp/secrets.bin --output text --query Plaintext | base64 -d > secrets.txt
 
+## Releasing a new version
+
+Please see [docs/releasing.md](docs/releasing.md)
+
 ## License
 
 Copyright (c) 2019 REA Group Ltd.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,6 +2,12 @@
 
 When you're ready to perform a new release, please do the following (sorry it's not fully automated):
 
+* Log into an AWS account and locate an enabled KMS key which has an alias
+* In your terminal, export the key ID as `SHUSH_KEY` and the alias as `SHUSH_ALIAS`
+* Run `make test` with the AWS credentials of the account that has the key
+
+Assuming the tests pass and you want to proceed with the release...
+
 * Change desired version in `main.go`
 * Commit and push to master
 * Run `auto/release-docker-image`

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,10 @@
+# Releasing a new version of Shush
+
+When you're ready to perform a new release, please do the following (sorry it's not fully automated):
+
+* Change desired version in `main.go`
+* Commit and push to master
+* Run `auto/release-docker-image`
+* Run `auto/binaries`
+* Create a new release in Github with your desired release notes, pointed at the version tag created by `auto/release-docker-image`
+* Attach the binaries from `target/*`

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.25.49
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/go-ini/ini v1.51.0
+	github.com/google/uuid v1.1.1
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 	github.com/urfave/cli v1.22.2
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/go-ini/ini v1.28.2 h1:drmmYv7psRpoGZkPtPKKTB+ZFSnvmwCMfNj5o1nLh2Y=
 github.com/go-ini/ini v1.28.2/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-ini/ini v1.51.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 h1:12VvqtR6Aowv3l/EQUlocDHW2Cp4G9WJVH7uyH8QFJE=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=

--- a/integration_tests/integration_test.go
+++ b/integration_tests/integration_test.go
@@ -50,7 +50,7 @@ func TestItEncryptsAndDecrypts(t *testing.T) {
 		t.FailNow()
 	}
 
-	keysToCheck := []string{key, alias}
+	keysToCheck := []string{key, alias, fmt.Sprintf("alias/%s", alias)}
 
 	for k := range keysToCheck {
 		encryptedValue := encryptValue(t, keysToCheck[k], expectedValue)

--- a/integration_tests/integration_test.go
+++ b/integration_tests/integration_test.go
@@ -1,0 +1,103 @@
+package integration_tests
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"testing"
+)
+
+const expectedValue = "superdupersecret"
+
+func TestMain(m *testing.M) {
+	// Builds from the latest sources to run our integration test
+	err := os.Chdir("..")
+	if err != nil {
+		fmt.Printf("could not change dir: %v", err)
+		os.Exit(1)
+	}
+	make := exec.Command("go", "build", "-o", "shush")
+	var stderr bytes.Buffer
+	make.Stderr = &stderr
+	err = make.Run()
+	if err != nil {
+		fmt.Printf("could not make binary for shush %v", err)
+		fmt.Printf(stderr.String())
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestItEncryptsAndDecrypts(t *testing.T) {
+	key := os.Getenv("SHUSH_KEY")
+
+	if key == "" {
+		t.Error("SHUSH_KEY was not found in environment. Please set this to a usable KMS key and re-run the test with appropriate AWS credentials")
+		t.FailNow()
+	}
+	alias := os.Getenv("SHUSH_ALIAS")
+
+	if alias == "" {
+		t.Error("SHUSH_ALIAS was not found in environment. Please set this to the alias of a usable KMS key and re-run the test with appropriate AWS credentials")
+		t.FailNow()
+	}
+
+	if _, err := os.Stat("shush"); os.IsNotExist(err) {
+		t.Error("Could not find shush binary")
+		t.FailNow()
+	}
+
+	keysToCheck := []string{key, alias}
+
+	for k := range keysToCheck {
+		encryptedValue := encryptValue(t, keysToCheck[k], expectedValue)
+		decryptValue(t, encryptedValue)
+	}
+}
+
+func decryptValue(t *testing.T, secret string) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	decryption := exec.Command(path.Join(dir, "shush"), "decrypt", secret)
+	var stdoutDecryption bytes.Buffer
+	var stderrDecryption bytes.Buffer
+	decryption.Stdout = &stdoutDecryption
+	decryption.Stderr = &stderrDecryption
+	err = decryption.Run()
+	if err != nil {
+		t.Errorf("Failed to decrypt: %v\n%s", err, stderrDecryption.String())
+	}
+
+	if stdoutDecryption.String() != expectedValue {
+		t.Errorf("Expected '%s' but got '%s'", expectedValue, stdoutDecryption.String())
+	}
+
+	return stdoutDecryption.String()
+}
+
+func encryptValue(t *testing.T, key string, secret string) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	encryption := exec.Command(path.Join(dir, "shush"), "encrypt", key, secret)
+	t.Logf("Running command 'shush encrypt %s %s'", key, secret)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	encryption.Stdout = &stdout
+	encryption.Stderr = &stderr
+	err = encryption.Run()
+	if err != nil {
+		t.Log(stdout.String())
+		t.Errorf("Failed to encrypt with key '%s': %v\n%s", key, err, stderr.String())
+		t.FailNow()
+	}
+
+	return stdout.String()
+}
+

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/realestate-com-au/shush/kms"
 	"github.com/realestate-com-au/shush/sys"
 	"github.com/urfave/cli"
@@ -45,6 +46,13 @@ func main() {
 					sys.Abort(sys.UsageError, "no key specified")
 				}
 				key := c.Args().First()
+
+				if !isValidUUID(key) {
+					if !strings.HasPrefix(key, "alias/") {
+						key = "alias/" + key
+					}
+				}
+
 				handle, err := kms.NewHandle(
 					c.GlobalString("region"),
 					c.GlobalStringSlice("context"),
@@ -147,4 +155,9 @@ func main() {
 
 	app.Run(os.Args)
 
+}
+
+func isValidUUID(u string) bool {
+	_, err := uuid.Parse(u)
+	return err == nil
 }

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 
 	app := cli.NewApp()
 	app.Name = "shush"
-	app.Version = "1.3.4"
+	app.Version = "1.4.0"
 	app.Usage = "KMS encryption and decryption"
 
 	app.Flags = []cli.Flag{


### PR DESCRIPTION
A mix of features and maintenance:

* Allows aliases to be specified _without_ `alias/`, saving those precious key-strokes
* Adds integration tests for a few scenarios
* Documents the release process