### PR TITLE
add build for linux/arm64

### DIFF
--- a/Dockerfile.xcompile
+++ b/Dockerfile.xcompile
@@ -6,4 +6,4 @@ ENV CGO_ENABLED=0
 
 COPY . /go/src/github.com/realestate-com-au/shush
 WORKDIR /go/src/github.com/realestate-com-au/shush
-RUN gox -osarch "linux/amd64 darwin/amd64 windows/amd64"
+RUN gox -osarch "linux/amd64 linux/arm64 darwin/amd64 windows/amd64"


### PR DESCRIPTION
Add linux/arm64 target, so we can run shush natively on AWS a1 instance types.
