### PR TITLE
README: Fix installation instructions to use sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ If you want to compile it from source, try:
 For Unix/Linux users, you can install `shush` using the following command. You may want to change the version number in the command below from `v1.4.0` to whichever version you want:
 
 ```
-curl -sL -o /usr/local/bin/shush \
+sudo curl -L -o /usr/local/bin/shush \
     https://github.com/realestate-com-au/shush/releases/download/v1.4.0/shush_linux_amd64 \
- && chmod +x /usr/local/bin/shush
+ && sudo chmod +x /usr/local/bin/shush
 ```
 
 ## Examples


### PR DESCRIPTION
The install command before the commit works fine in a Dockerfile but
when running it interactively most users are in a user account instead
of a root account. In addition, they want to see command output to check
for errors instead of curl silently failing as it happens when running
the command without root permissions.