### PR TITLE
Use build image for compilation to reduce the size of the target image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
-FROM golang:1.13-alpine
+FROM golang:1.13-alpine@sha256:7d45a6fc9cde63c3bf41651736996fe94a8347e726fe581926fd8c26e244e3b2 as build
 
 WORKDIR /go/src/github.com/realestate-com-au/shush
 COPY . /go/src/github.com/realestate-com-au/shush
 RUN go install
+
+FROM alpine:3.11@sha256:b276d875eeed9c7d3f1cfa7edb06b22ed22b14219a7d67c52c56612330348239
+
+RUN mkdir -p /go/bin
+
+USER nobody
+ENV PATH /go/bin:$PATH
+COPY --from=build /go/bin/shush /go/bin/shush
 
 ENTRYPOINT ["/go/bin/shush"]

--- a/Dockerfile.xcompile
+++ b/Dockerfile.xcompile
@@ -1,4 +1,4 @@
-FROM golang:1.13
+FROM golang:1.13@sha256:652c8f8ec2153ce500c7c8e984afd3115c1c58d3a0445643858930439d7664e1
 
 RUN go get github.com/mitchellh/gox
 


### PR DESCRIPTION
Currently the docker image size is 160MB because it includes temporary files created during the compilation step.

This change is using a separate build stage to compile the static binary which is then copied to the target image. The resulting image size is 20MB

Some additional changes:
* lock down the base images using sha256 checksums
* change the user to `nobody` because we don't need to be `root` to execute the program

Fixes #23 