### PR TITLE
Only add 'alias/' to key if it also doesn't start with an ARN path.

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func main() {
 				}
 				key := c.Args().First()
 
-				if !isValidUUID(key) {
+				if !isValidUUID(key) && !strings.HasPrefix(key, "arn:aws:kms") {
 					if !strings.HasPrefix(key, "alias/") {
 						key = "alias/" + key
 					}

--- a/main.go
+++ b/main.go
@@ -47,8 +47,8 @@ func main() {
 				}
 				key := c.Args().First()
 
-				if !isValidUUID(key) && !strings.HasPrefix(key, "arn:aws:kms") {
-					if !strings.HasPrefix(key, "alias/") {
+				if !isValidUUID(key) && !isArn(key) {
+					if !isAlias(key) {
 						key = "alias/" + key
 					}
 				}
@@ -160,4 +160,12 @@ func main() {
 func isValidUUID(u string) bool {
 	_, err := uuid.Parse(u)
 	return err == nil
+}
+
+func isArn(u string) bool {
+	return strings.HasPrefix(u, "arn:aws:kms")
+}
+
+func isAlias(u string) bool {
+	return strings.HasPrefix(u, "alias/")
 }


### PR DESCRIPTION
This PR is to fix an issue when accessing cross-account KMS keys via their full ARN. 

`shush` attempts to add `alias/` when provided with a full ARN, for example:
`arn:aws:kms:ap-southeast-2:<account 1>:alias/arn:aws:kms:ap-southeast-2:<account 2>:key/<key id>`

With `<account 1>` being the originator of the requests and `<account 2>` being the source of the KMS key.

I do not know why this behaviour has become apparent now (old versions of `shush` floating around?) however there is this [issue](https://github.com/realestate-com-au/shush/issues/21) that should be addressed by this PR.