### PR TITLE
add a double quote to avoid some terminals auto escape $ to \$

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ For Unix/Linux users, you can install `shush` using the following command. You m
 
 ```
 sudo curl -fsSL -o /usr/local/bin/shush \
-    https://github.com/realestate-com-au/shush/releases/download/v1.5.2/shush_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_/amd/' | sed 's/aarch/arm/') \
+    "https://github.com/realestate-com-au/shush/releases/download/v1.5.2/shush_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_/amd/' | sed 's/aarch/arm/')" \
  && sudo chmod +x /usr/local/bin/shush
 ```
 


### PR DESCRIPTION
installation script escape `$` to `\$`  automatically in some terminal eg: iterm2 + zsh, which make installation in mac failed and get the error: `zsh: parse error near `)'`

add a double quote to avoid some terminals auto escape `$` to `\$`