### PR TITLE
Add support for IMDSv2

### DIFF
--- a/awsmeta/awsmeta.go
+++ b/awsmeta/awsmeta.go
@@ -12,7 +12,7 @@ func GetMetaData(path string) (contents []byte, err error) {
 	url := "http://169.254.169.254/latest/meta-data/" + path
 
 	req, _ := http.NewRequest("GET", url, nil)
-	if meatadataToken, _ := GetMetadataToken(); meatadataToken != "" {
+	if meatadataToken, _ := getMetaDataToken(); meatadataToken != "" {
 		req.Header.Set("X-aws-ec2-metadata-token", meatadataToken)
 	}
 
@@ -59,8 +59,8 @@ func GetRegion() string {
 	return string(az[:len(az)-1])
 }
 
-// GetMetadataToken ... get a metadata token for IMDSv2
-func GetMetadataToken() (token string, err error) {
+// getMetaDataToken ... get a metadata token for IMDSv2
+func getMetaDataToken() (token string, err error) {
 	url := "http://169.254.169.254/latest/api/token"
 
 	req, _ := http.NewRequest("PUT", url, nil)

--- a/awsmeta/awsmeta.go
+++ b/awsmeta/awsmeta.go
@@ -12,8 +12,8 @@ func GetMetaData(path string) (contents []byte, err error) {
 	url := "http://169.254.169.254/latest/meta-data/" + path
 
 	req, _ := http.NewRequest("GET", url, nil)
-	if meatadataToken, _ := getMetaDataToken(); meatadataToken != "" {
-		req.Header.Set("X-aws-ec2-metadata-token", meatadataToken)
+	if metadataToken, _ := getMetaDataToken(); metadataToken != "" {
+		req.Header.Set("X-aws-ec2-metadata-token", metadataToken)
 	}
 
 	client := http.Client{

--- a/awsmeta/awsmeta.go
+++ b/awsmeta/awsmeta.go
@@ -9,11 +9,10 @@ import (
 
 // GetMetaData ... fetch AWS meta-data.
 func GetMetaData(path string) (contents []byte, err error) {
-	meatadataToken, _ := GetMetadataToken()
 	url := "http://169.254.169.254/latest/meta-data/" + path
 
 	req, _ := http.NewRequest("GET", url, nil)
-	if meatadataToken != "" {
+	if meatadataToken, _ := GetMetadataToken(); meatadataToken != "" {
 		req.Header.Set("X-aws-ec2-metadata-token", meatadataToken)
 	}
 

--- a/awsmeta/awsmeta.go
+++ b/awsmeta/awsmeta.go
@@ -9,9 +9,14 @@ import (
 
 // GetMetaData ... fetch AWS meta-data.
 func GetMetaData(path string) (contents []byte, err error) {
+	meatadataToken, _ := GetMetadataToken()
 	url := "http://169.254.169.254/latest/meta-data/" + path
 
 	req, _ := http.NewRequest("GET", url, nil)
+	if meatadataToken != "" {
+		req.Header.Set("X-aws-ec2-metadata-token", meatadataToken)
+	}
+
 	client := http.Client{
 		Timeout: time.Millisecond * 100,
 	}
@@ -53,4 +58,36 @@ func GetRegion() string {
 
 	//returns us-west-2a, just return us-west-2
 	return string(az[:len(az)-1])
+}
+
+// GetMetadataToken ... get a metadata token for IMDSv2
+func GetMetadataToken() (token string, err error) {
+	url := "http://169.254.169.254/latest/api/token"
+
+	req, _ := http.NewRequest("PUT", url, nil)
+	req.Header.Set("X-aws-ec2-metadata-token-ttl-seconds", "5")
+
+	client := http.Client{
+		Timeout: time.Millisecond * 100,
+	}
+
+	resp, err := client.Do(req)
+
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		err = fmt.Errorf("awsmeta: code %d returned for url %s", resp.StatusCode, url)
+		return
+	}
+
+	body, err := io.ReadAll(resp.Body)
+
+	if err != nil {
+		return
+	}
+
+	return string(body), err
 }


### PR DESCRIPTION
If the EC2 instance has IMDSv2 set to "required", shush is currently unable to auto-discover the region. This change will make an attempt to generate a metadata token and use it when fetching the region. Current behaviour is used if this fails for whatever reason.

https://aws.amazon.com/blogs/security/get-the-full-benefits-of-imdsv2-and-disable-imdsv1-across-your-aws-infrastructure/